### PR TITLE
start of investigation into wrapnzap boost graph deploy

### DIFF
--- a/manifests/config.js
+++ b/manifests/config.js
@@ -21,6 +21,17 @@ module.exports.config = {
     ],
     templates: [],
   },
+  "optimism": {
+    dataSources: [
+      {
+        name: "wrapNZap",
+        template: "wrapNZap-ds.yaml",
+        address: "", // TODO add wrapnzap address
+        startBlock: 249938, // TODO add startBlock
+      },
+    ],
+    templates: [],
+  },
   celo: {
     dataSources: [
       {

--- a/manifests/config.js
+++ b/manifests/config.js
@@ -26,8 +26,8 @@ module.exports.config = {
       {
         name: "wrapNZap",
         template: "wrapNZap-ds.yaml",
-        address: "", // TODO add wrapnzap address
-        startBlock: 249938, // TODO add startBlock
+        address: "0x5D1ADccB9092eFc65E094Dd8972Bc0d9224b3C41",
+        startBlock: 4865606, // TODO see PR details - not sure if this is correct.
       },
     ],
     templates: [],

--- a/manifests/wrapNZap-ds.yaml
+++ b/manifests/wrapNZap-ds.yaml
@@ -1,10 +1,10 @@
 kind: ethereum/contract
 name: WrapNZapFactory
-network:
+network: optimism
 source:
-  address: ""
+  address: "" # TODO fill out after wrap and zap deploy
   abi: WrapNZapFactory
-  startBlock:
+  startBlock: # TODO fill out after wrap and zap deploy
 mapping:
   kind: ethereum/events
   apiVersion: 0.0.3

--- a/package.json
+++ b/package.json
@@ -15,13 +15,15 @@
     "prepare:rinkeby": "node manifests/deploy-prep.js rinkeby",
     "prepare:arbitrum": "node manifests/deploy-prep.js arbitrum-one",
     "prepare:celo": "node manifests/deploy-prep.js celo",
+    "prepare:optimism": "node manifests/deploy-prep.js optimism",
     "deploy:mainnet": "yarn prepare:mainnet && yarn build:all && graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ odyssy-automaton/daohaus-boosts",
     "deploy:xdai": "yarn prepare:xdai && yarn build:all && graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ odyssy-automaton/daohaus-boosts-xdai",
     "deploy:matic": "yarn prepare:matic && yarn build:all && graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ odyssy-automaton/daohaus-boosts-matic",
     "deploy:kovan": "yarn prepare:kovan && yarn build:all && graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ odyssy-automaton/daohaus-boosts-kovan",
     "deploy:rinkeby": "yarn prepare:rinkeby && yarn build:all && graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ odyssy-automaton/daohaus-boosts-rinkeby",
     "deploy:arbitrum": "yarn prepare:arbitrum && yarn build:all && graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ odyssy-automaton/daohaus-boosts-arbitrum",
-    "deploy:celo": "yarn prepare:celo && yarn build:all && graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ odyssy-automaton/daohaus-boosts-celo"
+    "deploy:celo": "yarn prepare:celo && yarn build:all && graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ odyssy-automaton/daohaus-boosts-celo",
+    "deploy:optimism": "yarn prepare:optimism && yarn build:all && graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ odyssy-automaton/daohaus-boosts-optimism"
   },
   "devDependencies": {
     "@graphprotocol/graph-cli": "^0.19.0",

--- a/subgraph-template.yaml
+++ b/subgraph-template.yaml
@@ -7,13 +7,13 @@ dataSources:
   - kind: ethereum/contract
     name: WrapNZapFactory
     # network: mainnet
-    network: celo
+    network: optimism
     source:
       # address: "0x2840d12d926cc686217bb42b80b662c7d72ee787"
-      address: '0x07269699bc441FC97d12d5478Cb09522EF32f76A'
+      address: '0x07269699bc441FC97d12d5478Cb09522EF32f76A' # TODO fill out after wrap and zap deploy
       abi: WrapNZapFactory
       # startBlock: 8625240
-      startBlock: 8691309
+      startBlock:  # TODO fill out after wrap and zap deploy
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4

--- a/subgraph-template.yaml
+++ b/subgraph-template.yaml
@@ -1,0 +1,30 @@
+specVersion: 0.0.2
+description: DAOHaus Boosts Subgraph
+repository: 'https://github.com/hausdao/daohaus-boosts-subgraph'
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: ethereum/contract
+    name: WrapNZapFactory
+    # network: mainnet
+    network: celo
+    source:
+      # address: "0x2840d12d926cc686217bb42b80b662c7d72ee787"
+      address: '0x07269699bc441FC97d12d5478Cb09522EF32f76A'
+      abi: WrapNZapFactory
+      # startBlock: 8625240
+      startBlock: 8691309
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.4
+      language: wasm/assemblyscript
+      entities:
+        - WrapNZap
+      abis:
+        - name: WrapNZapFactory
+          file: ./abis/WrapNZapFactory.json
+      eventHandlers:
+        - event: 'NewWrapNZap(address,address,address)'
+          handler: handleNewWrapNZap
+      file: ./src/wrap-n-zap-mappings.ts
+templates: []

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -6,7 +6,7 @@ schema:
 dataSources:
   - kind: ethereum/contract
     name: WrapNZapFactory
-    network: celo
+    network: optimism
     source:
       address: '0x07269699bc441FC97d12d5478Cb09522EF32f76A'
       abi: WrapNZapFactory


### PR DESCRIPTION
WIP branch for adding optimism to HausDAO

a little confused with configuring the `startBlock`on Optimism - making note of [how blocks and time work on Optimism](https://community.optimism.io/docs/developers/build/differences/#block-numbers-and-timestamps) - might be nothing - right now I am using the `Transaction Index` off the deploy tx.

UPDATE - i got an answer to the above question in the Optimism dev support discord - Transaction index is the right attribute to use for subgraphs - heres [the reference](https://discord.com/channels/667044843901681675/887914409207414785/957407954901020713) - might not work for you unless your in their dev discord so heres the back and forth:

![Screen Shot 2022-03-26 at 8 47 26 PM](https://user-images.githubusercontent.com/5998100/160264583-0d26fff1-c293-4ee3-b551-4a302da293e0.png)

[Deploy Transaction for `WrapNZapFactory`](https://optimistic.etherscan.io/tx/0x7526f5d56d6349ca95bdfea01891a7388fc6f842a103cdb77846adf20a925f23)